### PR TITLE
Handle missing SSH config

### DIFF
--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -28,7 +28,7 @@ class Dagobah(object):
     """
 
     def __init__(self, backend=BaseBackend(), event_handler=None,
-                 ssh_config="~/.ssh/config"):
+                 ssh_config=None):
         """ Construct a new Dagobah instance with a specified Backend. """
         self.backend = backend
         self.event_handler = event_handler
@@ -163,14 +163,21 @@ class Dagobah(object):
         job.commit()
 
     def load_ssh_conf(self):
-        conf_file = open(os.path.expanduser(self.ssh_config))
-        ssh_config = paramiko.SSHConfig()
-        ssh_config.parse(conf_file)
-        conf_file.close()
-        return ssh_config
+        try:
+            conf_file = open(os.path.expanduser(self.ssh_config))
+            ssh_config = paramiko.SSHConfig()
+            ssh_config.parse(conf_file)
+            conf_file.close()
+            return ssh_config
+        except IOError:
+            # SSH config not found
+            return None
 
     def get_hosts(self):
         conf = self.load_ssh_conf()
+
+        if conf is None:
+            return []
 
         # Please help me make this cleaner I'm in list comprehension hell
 

--- a/dagobah/daemon/daemon.py
+++ b/dagobah/daemon/daemon.py
@@ -128,6 +128,9 @@ def init_dagobah(testing=False):
     event_handler = configure_event_hooks(config)
     ssh_config = get_conf(config, 'Dagobahd.ssh_config', '~/.ssh/config')
 
+    if not os.path.isfile(os.path.expanduser(ssh_config)):
+        logging.warn("SSH config doesn't exist, no remote hosts will be listed")
+
     dagobah = Dagobah(backend, event_handler, ssh_config)
     known_ids = [id for id in backend.get_known_dagobah_ids()
                  if id != dagobah.dagobah_id]


### PR DESCRIPTION
Closes #95

First checks on config load if the file is missing, and logs a warning if the file does not exist.

Then during the loading of the config, if the file doesnt exist, the config becomes None.

In methods that use the config, I added code to handle the None case.
