### PR TITLE
Fixing hostname error

### DIFF
--- a/dagobah/daemon/api.py
+++ b/dagobah/daemon/api.py
@@ -396,7 +396,7 @@ def edit_task():
     # validate host
     if args.get('hostname') not in dagobah.get_hosts():
         # Check for empty host, if so then task is no longer remote
-        if args.get('hostname') == '' or args.get('hostname') is None:
+        if not args.get('hostname'):
             args['hostname'] = None
         else:
             abort(400)


### PR DESCRIPTION
When you create a task without a host, and then try to edit it, this originally gave a 400 error because hostname was never set, and there was no check for "None". This fixes that.
