### PR TITLE
Replace "raise" with logger.error

### DIFF
--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -559,8 +559,8 @@ class Job(DAG):
         try:
             self.backend.acquire_lock()
             self._commit_run_log()
-        except Exception as e:
-            logger.error(e)
+        except:
+            logger.exception("Error in handling events.")
         finally:
             self.backend.release_lock()
 
@@ -571,8 +571,8 @@ class Job(DAG):
                 if self.event_handler:
                     self.event_handler.emit('task_failed',
                                             task._serialize(include_run_logs=True))
-            except Exception as e:
-                logger.error(e)
+            except:
+                logger.exception("Error in handling events.")
             finally:
                 self.backend.release_lock()
 
@@ -609,8 +609,8 @@ class Job(DAG):
                     if self.event_handler:
                         self.event_handler.emit('job_failed',
                                                 self._serialize(include_run_logs=True))
-                except Exception as e:
-                    logger.error(e)
+                except:
+                    logger.exception("Error in handling events.")
                 finally:
                     self.backend.release_lock()
                 break
@@ -623,8 +623,8 @@ class Job(DAG):
                 if self.event_handler:
                     self.event_handler.emit('job_complete',
                                             self._serialize(include_run_logs=True))
-            except Exception as e:
-                logger.error(e)
+            except:
+                logger.exception("Error in handling events.")
             finally:
                 self.backend.release_lock()
 


### PR DESCRIPTION
Addresses #130/#129 for now by avoiding weird erroneous states in dagobah, but more long term work will need to be done to handle error states more specifically and gracefully.
