### PR TITLE
Adding index to save_date

### DIFF
--- a/dagobah/backend/mongo.py
+++ b/dagobah/backend/mongo.py
@@ -48,6 +48,8 @@ class MongoBackend(BaseBackend):
         self.job_coll = self.db[job_collection]
         self.log_coll = self.db[log_collection]
 
+        self.log_coll.ensure_index("save_date")
+
     def __repr__(self):
         return '<MongoBackend (host: %s, port: %s)>' % (self.host, self.port)
 


### PR DESCRIPTION
Fixes #129 as well as a few others that this problem cascaded onto.

Verified that it added the index on a new instance using mongo shell:

```
$ mongo
MongoDB shell version: 2.6.1
connecting to: test
> use dagobah
switched to db dagobah
> db.dagobah_log.getIndexes()
[
    {
        "v" : 1,
        "key" : {
            "_id" : 1
        },
        "name" : "_id_",
        "ns" : "dagobah.dagobah_log"
    },
    {
        "v" : 1,
        "key" : {
            "save_date" : 1
        },
        "name" : "save_date_1",
        "ns" : "dagobah.dagobah_log"
    }
]
>
```

![selfie-0](http://i.imgur.com/cIK1h6p.png)
sorry I havent been submitting my PRs with selfies
