### PR TITLE
Use all email recipients

### DIFF
--- a/dagobah/email/common.py
+++ b/dagobah/email/common.py
@@ -68,7 +68,7 @@ class EmailTemplate(object):
             s.login(self.user, self.password)
 
         s.sendmail(self.message['From'],
-                   self.message['To'],
+                   self.recipients,
                    self.message.as_string())
 
 


### PR DESCRIPTION
Using a string in the second parameter in sendmail call causes emails
to be sent just to the first address. Using a list causes will ensure
the correct behaviour.
