### PR TITLE
Use pkg_resource api to get config file

### DIFF
--- a/dagobah/__init__.py
+++ b/dagobah/__init__.py
@@ -1,9 +1,7 @@
 import os
+from pkg_resources import resource_string
 
 from .core import *
-
-config_file_default_location = os.path.realpath(os.path.join(os.getcwd(),
-                                                             'dagobah/daemon'))
 
 def print_standard_conf():
     """ Print the sample config file to stdout. """
@@ -11,8 +9,6 @@ def print_standard_conf():
 
 def return_standard_conf():
     """ Return the sample config file. """
-    config_file = open(os.path.join(config_file_default_location, 'dagobahd.yml'))
-    result = config_file.read()
-    config_file.close()
+    result = resource_string(__name__, 'daemon/dagobahd.yml')
     result = result % {'app_secret': os.urandom(24).encode('hex')}
     return result


### PR DESCRIPTION
On OS X, installing from pip, the initial execution is broken when you run in any directory other than the one `__init__.py` happens to be in. One fix is to use `__file__` to find the config file; the setuptools people discourage this because you could be running from a zipfile or an egg or whatever. So `pkg_resources.resource_string` seems to be the way to go.
