### PR TITLE
Rmc job in job datamodel

### DIFF
--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -690,6 +690,22 @@ class Job(DAG):
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
         return result
 
+    def implements_expandable(obj):
+        """ Checks for methods required to expand a task """
+        for expected_method in ['expand']:
+            if not (hasattr(obj, expected_method) and
+                    callable(getattr(obj, expected_method))):
+                return False
+        return True
+
+    def implements_runnable(obj):
+        """ Checks methods required to run a task. More methods to be added """
+        for expected_method in ['start']:
+            if not (hasattr(obj, expected_method) and
+                    callable(getattr(obj, expected_method))):
+                return False
+        return True
+
     def initialize_snapshot(self):
         """ Copy the DAG and validate """
         logger.debug('Initializing DAG snapshot for job {0}'.format(self.name))
@@ -1099,4 +1115,22 @@ class Task(object):
 
         if strict_json:
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
+        return result
+
+
+class JobTask(object):
+    """ Expandable Task that references a job """
+    def __init__(self, parent_job, job_name):
+        self.parent_job = parent_job
+        self.job_name = job_name
+
+    def expand(self):
+        """ Expand this JobTask into a list of tasks """
+        return self.parent.parent.get_job(self.job_name).tasks.values()
+
+    def _serialize(self, include_run_logs=False, strict_json=False):
+        """ Serialize a representation of this Task to a Python dict. """
+
+        result = {'job_name': self.job_name}
+
         return result

--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -1131,6 +1131,8 @@ class JobTask(object):
     def _serialize(self, include_run_logs=False, strict_json=False):
         """ Serialize a representation of this Task to a Python dict. """
 
-        result = {'job_name': self.job_name}
+        result = {
+            'name': self.task_name
+            'job_name': self.job_name}
 
         return result

--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -1168,14 +1168,14 @@ class Task(object):
 
 class JobTask(object):
     """ Expandable Task that references a job """
-    def __init__(self, parent_job, job_name, task_name):
+    def __init__(self, parent_job, target_job_name, task_name):
         self.parent_job = parent_job
-        self.job_name = job_name
+        self.target_job_name = target_job_name
         self.name = task_name
 
     def expand(self):
         """ Expand this JobTask into a list of tasks """
-        return self.parent.parent.get_job(self.job_name).tasks.values()
+        return self.parent_job.parent.get_job(self.target_job_name).tasks.values()
 
     def _serialize(self, include_run_logs=False, strict_json=False):
         """ Serialize a representation of this Task to a Python dict. """

--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -257,8 +257,7 @@ class Dagobah(object):
         job.commit()
 
 
-    def add_jobtask_to_job(self, job_or_job_name, target_job, task_name=None,
-                        **kwargs):
+    def add_jobtask_to_job(self, job_or_job_name, target_job, task_name=None):
         """ Add a task to a job owned by the Dagobah instance. """
 
         if isinstance(job_or_job_name, Job):

--- a/dagobah/core/core.py
+++ b/dagobah/core/core.py
@@ -738,21 +738,25 @@ class Job(DAG):
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
         return result
 
-    def implements_expandable(obj):
-        """ Checks for methods required to expand a task """
-        for expected_method in ['expand']:
+
+    def _implements_function(obj, functions):
+        """ Checks for the existence of a method or list of methods """
+        for expected_method in functions:
             if not (hasattr(obj, expected_method) and
                     callable(getattr(obj, expected_method))):
                 return False
         return True
 
+
+    def implements_expandable(obj):
+        """ Checks for methods required to expand a task """
+        return self._implements_function(obj, 'expand')
+
+
     def implements_runnable(obj):
         """ Checks methods required to run a task. More methods to be added """
-        for expected_method in ['start']:
-            if not (hasattr(obj, expected_method) and
-                    callable(getattr(obj, expected_method))):
-                return False
-        return True
+        return self._implements_function(obj, 'start')
+
 
     def initialize_snapshot(self):
         """ Copy the DAG and validate """


### PR DESCRIPTION
Moving this over from #155 

This PR gives support for the concept of a `JobTask`, which is a task that references another job. It also provides methods to distinguish them (`is_expandable` and `is_runnable`) as well as methods to add a `JobTask` to the graph (in the back end)

I'm putting up this PR so that it can be reviewed ASAP, but I am still working on adding unit tests.