### PR TITLE
Cycle Detection

### DIFF
--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -439,15 +439,11 @@ class Job(DAG):
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
         return result
 
-    def _implements_function(self, obj, functions):
-        """ Checks for the existence of a method or list of methods """
-        if isinstance(functions, str):
-            functions = [functions]
-        logger.debug("Checking if {0} implements {1}".format(obj, functions))
-        for expected_method in functions:
-            if not (hasattr(obj, expected_method) and
-                    callable(getattr(obj, expected_method))):
-                return False
+    def _implements_function(self, obj, function):
+        """ Checks for the existence of a method """
+        if not (hasattr(obj, function) and
+                callable(getattr(obj, function))):
+            return False
         return True
 
     def implements_expandable(self, obj):

--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -479,6 +479,13 @@ class Job(DAG):
         Verify that the job has no cycles where a JobTask circularly
         references another JobTask so that we know we can safely snapshot
         the DAG.
+
+        Returns:
+            bool -- indicating successful verification with True.
+
+        Raises:
+            DagobahException -- when a JobTask references a non-existent job.
+
         Explanation:
             1. If the current job is in the context, the job is not valid
             2. Perform a topological sort without expanding tasks (current job
@@ -487,7 +494,7 @@ class Job(DAG):
                Job, run verify on that node, passing in the current context.
         """
         # Check if job is not in current context, then add it
-        logger.info("Verifying DAG for {0}".format(self.name))
+        logger.debug("Verifying DAG for {0}".format(self.name))
         if context is None:
             logger.debug("No context set, using empty set")
             context = set()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='dagobah',
                         'flask-login==0.2.6',
                         'semantic_version==2.3.0',
                         'paramiko==1.11.0',
-                        'py-dag==1.0.0'],
+                        'py-dag==2.0.0'],
       test_suite='nose.collector',
       tests_require=['nose', 'pymongo'],
       entry_points={'console_scripts':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,27 +10,28 @@ from nose.tools import nottest, raises, assert_equal
 
 from dagobah.core.dagobah import Dagobah
 from dagobah.core.dagobah_error import DagobahError
-from dagobah.core.job import Job
-from dagobah.core.task import Task
-from dagobah.core.jobtask import JobTask
 from dagobah.backend.base import BaseBackend
 
 import os
 
 dagobah = None
 
+
 class DagobahTestTimeoutException(Exception):
     pass
+
 
 @nottest
 def raise_timeout_exception(*args, **kwargs):
     raise DagobahTestTimeoutException()
+
 
 @nottest
 def wait_until_stopped(job):
     while job.state.status == 'running':
         sleep(0.1)
         continue
+
 
 @nottest
 def supports_timeouts(fn):
@@ -42,6 +43,7 @@ def supports_timeouts(fn):
         signal.signal(signal.SIGALRM, lambda signalnum, handler: None)
         return result
     return wrapped
+
 
 @nottest
 def blank_dagobah():
@@ -102,14 +104,14 @@ def test_dagobah_add_tasks():
 
 
 @with_setup(blank_dagobah)
-def test_dagobah_delete_job():
+def test_dagobah_delete_job2():
     dagobah.add_job('test_job')
     dagobah.delete_job('test_job')
 
 
 @with_setup(blank_dagobah)
 @raises(DagobahError)
-def test_dagobah_delete_job_does_not_exist():
+def test_dagobah_delete_job_does_not_exist2():
     dagobah.add_job('test_job')
     dagobah.delete_job('test_job_2')
 
@@ -230,7 +232,7 @@ def test_serialize_dagobah():
                                         'success': None,
                                         'soft_timeout': 0,
                                         'hard_timeout': 0,
-                                        'hostname': None},],
+                                        'hostname': None}, ],
                              'dependencies': {'list': ['grep'],
                                               'grep': []},
                              'status': 'waiting',
@@ -275,12 +277,14 @@ def test_construct_with_timeouts():
     assert job.tasks['From Job'].soft_timeout == 10
     assert job.tasks['From Job'].hard_timeout == 20
 
+
 @with_setup(blank_dagobah)
 def test_ssh_config_load():
     hosts = dagobah.get_hosts()
     assert "test_host" in hosts
     assert "*" not in hosts
     assert "nonexistant" not in hosts
+
 
 @with_setup(blank_dagobah)
 @supports_timeouts
@@ -314,6 +318,7 @@ def test_retry_from_failure():
     wait_until_stopped(job)
     assert job.state.status != 'failed'
 
+
 @with_setup(blank_dagobah)
 def test_dagobah_add_jobtasks():
     dagobah.add_job('test_job_a')
@@ -322,7 +327,8 @@ def test_dagobah_add_jobtasks():
     job_b = dagobah.get_job('test_job_b')
     job_a.add_task('ls')
     job_b.add_jobtask('test_job_a')
-    assert "test_job_a" in [task.target_job_name for task in job_b.tasks.values()]
+    assert "test_job_a" in [t.target_job_name for t in job_b.tasks.values()]
+
 
 @with_setup(blank_dagobah)
 def test_verify_no_jobtasks():
@@ -336,6 +342,7 @@ def test_verify_no_jobtasks():
     job.add_edge('ls', 'pwd')
     job.add_edge('pwd', 'sleep 1')
     assert job.verify()
+
 
 @with_setup(blank_dagobah)
 def test_verify_with_jobtasks():
@@ -352,6 +359,7 @@ def test_verify_with_jobtasks():
     assert a.verify()
     assert b.verify()
 
+
 @with_setup(blank_dagobah)
 def test_verify_detect_cycle():
     dagobah.add_job('A')
@@ -364,6 +372,7 @@ def test_verify_detect_cycle():
 
     assert not a.verify()
     assert not b.verify()
+
 
 @with_setup(blank_dagobah)
 def test_verify_detect_cycle_complex():


### PR DESCRIPTION
This pull request is to add the `verify()` method to the `Job` class, which verifies that there are no cycles in the job, include cross-job cycles.

Included are a few unit tests, including one really complex job where I tried to combine every possible way of linking jobs, verify them, and then add a loop at the end and make sure it can detect a loop deep in.

If you think of any edge cases you want me to cover, let me know!