### PR TITLE
Rmc dev job in job expansion

### DIFF
--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -475,19 +475,8 @@ class Job(DAG):
             raise DagobahError("Job has a cycle, possibly within another Job "
                                + "reference")
 
-        # Due to thread locks in underlying tasks, they must be manually copied
-        tasks_copy = {}
-        for name, task in self.tasks.iteritems():
-            if self.implements_runnable(task):
-                tasks_copy[name] = Task(self, task.command, task.name,
-                                        soft_timeout=task.soft_timeout,
-                                        hard_timeout=task.hard_timeout,
-                                        hostname=task.hostname)
-            elif self.implements_expandable(task):
-                tasks_copy[name] = JobTask(self, task.name,
-                                           task.target_job_name)
-            else:
-                raise DagobahError("Malformed task neither a Task nor JobTask")
+        # Due to thread locks in underlying tasks, they cannot be deepcopy'd
+        tasks_copy = dict((n, t.clone()) for (n, t) in self.tasks.iteritems())
 
         self.snapshot, self.tasks_snapshot = self.expand(snapshot_to_validate,
                                                          tasks_copy)

--- a/dagobah/core/jobtask.py
+++ b/dagobah/core/jobtask.py
@@ -2,7 +2,6 @@ import logging
 import json
 
 from .components import StrictJSONEncoder
-from .dagobah_error import DagobahError
 
 logger = logging.getLogger('dagobah')
 
@@ -18,8 +17,8 @@ class JobTask(object):
 
     def expand(self):
         """ Expand this JobTask into a list of tasks """
-        return self.parent_job.parent.get_job(
-            self.target_job_name).tasks.values()
+        target_job = self.parent_job.parent._resolve_job(self.target_job_name)
+        return target_job.expand()
 
     def _serialize(self, include_run_logs=False, strict_json=False):
         """ Serialize a representation of this Task to a Python dict. """

--- a/dagobah/core/jobtask.py
+++ b/dagobah/core/jobtask.py
@@ -18,7 +18,7 @@ class JobTask(object):
     def expand(self):
         """ Expand this JobTask into a list of tasks """
         target_job = self.parent_job.parent._resolve_job(self.target_job_name)
-        return target_job.expand()
+        return target_job.expand(target_job.graph, target_job.tasks)
 
     def _serialize(self, include_run_logs=False, strict_json=False):
         """ Serialize a representation of this Task to a Python dict. """

--- a/dagobah/core/jobtask.py
+++ b/dagobah/core/jobtask.py
@@ -29,3 +29,7 @@ class JobTask(object):
         if strict_json:
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
         return result
+
+    def clone(self):
+        cloned_task = JobTask(self.parent_job, self.name, self.target_job_name)
+        return cloned_task

--- a/dagobah/core/task.py
+++ b/dagobah/core/task.py
@@ -387,3 +387,10 @@ class Task(object):
         if strict_json:
             result = json.loads(json.dumps(result, cls=StrictJSONEncoder))
         return result
+
+    def clone(self):
+        cloned_task = Task(self.parent_job, self.command, self.name,
+                           soft_timeout=self.soft_timeout,
+                           hard_timeout=self.hard_timeout,
+                           hostname=self.hostname)
+        return cloned_task

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ premailer==1.13
 flask-login==0.2.6
 semantic_version==2.3.0
 paramiko==1.11.0
-py-dag==1.0.0
+py-dag==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='dagobah',
                         'flask-login==0.2.6',
                         'semantic_version==2.3.0',
                         'paramiko==1.11.0',
-                        'py-dag==2.0.0'],
+                        'py-dag==2.1.0'],
       test_suite='nose.collector',
       tests_require=['nose', 'pymongo'],
       entry_points={'console_scripts':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -462,7 +462,7 @@ def test_dagobah_expand_empty_job():
     graph, tasks = job_b.expand(job_b.graph, job_b.tasks)
     pprint(graph)
     pprint(tasks)
-    assert_equal(pformat(graph), "{'ls': set(['pwd']), 'pwd': set()}")
+    assert_equal(pformat(graph), "{'ls': set(['pwd']), 'pwd': set([])}")
 
 
 @with_setup(blank_dagobah)
@@ -480,7 +480,7 @@ def test_dagobah_expand_simple_job():
     graph, tasks = job_b.expand(job_b.graph, job_b.tasks)
     assert_equal(pformat(graph),
                  "{'ls': set(['test_job_a_yes']), " +
-                 "'pwd': set(), " +
+                 "'pwd': set([]), " +
                  "'test_job_a_yes': set(['pwd'])}")
 
 
@@ -505,7 +505,7 @@ def test_dagobah_expand_moderate_job():
     pprint(graph)
     assert_equal(pformat(graph),
                  "{'ls': set(['test_job_a_yes'])," +
-                 "\n 'pwd': set()," +
+                 "\n 'pwd': set([])," +
                  "\n 'test_job_a_cd .': set(['pwd'])," +
                  "\n 'test_job_a_ls': set(['test_job_a_cd .'])," +
                  "\n 'test_job_a_yes': set(['test_job_a_ls'])}")
@@ -559,5 +559,5 @@ def test_dagobah_expand_complex_job():
                  "\n 'C_C_B*_D**': set(['C_C_C*', 'C_C_D*'])," +
                  "\n 'C_C_C*': set(['C_C_D*'])," +
                  "\n 'C_C_D*': set(['D', 'E'])," +
-                 "\n 'D': set()," +
-                 "\n 'E': set()}")
+                 "\n 'D': set([])," +
+                 "\n 'E': set([])}")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,6 +12,8 @@ from dagobah.core.dagobah import Dagobah
 from dagobah.core.dagobah_error import DagobahError
 from dagobah.backend.base import BaseBackend
 
+from pprint import pprint, pformat
+
 import os
 
 dagobah = None
@@ -435,3 +437,127 @@ def test_verify_detect_cycle_complex():
     assert not c.verify()
     assert not d.verify()
     assert not e.verify()
+
+
+@with_setup(blank_dagobah)
+def test_dagobah_expand_none():
+    dagobah.add_job('test_job_a')
+    job_a = dagobah.get_job('test_job_a')
+    job_a.add_task('ls')
+    graph, tasks = job_a.expand(job_a.graph, job_a.tasks)
+    pprint(graph)
+    pprint(tasks)
+
+
+@with_setup(blank_dagobah)
+def test_dagobah_expand_empty_job():
+    dagobah.add_job('test_job_a')
+    dagobah.add_job('test_job_b')
+    job_b = dagobah.get_job('test_job_b')
+    job_b.add_task('ls')
+    job_b.add_task('pwd')
+    job_b.add_jobtask('test_job_a')
+    job_b.add_edge('ls', 'test_job_a')
+    job_b.add_edge('test_job_a', 'pwd')
+    graph, tasks = job_b.expand(job_b.graph, job_b.tasks)
+    pprint(graph)
+    pprint(tasks)
+    assert_equal(pformat(graph), "{'ls': set(['pwd']), 'pwd': set()}")
+
+
+@with_setup(blank_dagobah)
+def test_dagobah_expand_simple_job():
+    dagobah.add_job('test_job_a')
+    dagobah.add_job('test_job_b')
+    job_a = dagobah.get_job('test_job_a')
+    job_a.add_task('yes')
+    job_b = dagobah.get_job('test_job_b')
+    job_b.add_task('ls')
+    job_b.add_task('pwd')
+    job_b.add_jobtask('test_job_a')
+    job_b.add_edge('ls', 'test_job_a')
+    job_b.add_edge('test_job_a', 'pwd')
+    graph, tasks = job_b.expand(job_b.graph, job_b.tasks)
+    assert_equal(pformat(graph),
+                 "{'ls': set(['test_job_a_yes']), " +
+                 "'pwd': set(), " +
+                 "'test_job_a_yes': set(['pwd'])}")
+
+
+@with_setup(blank_dagobah)
+def test_dagobah_expand_moderate_job():
+    dagobah.add_job('test_job_a')
+    dagobah.add_job('test_job_b')
+    job_a = dagobah.get_job('test_job_a')
+    job_a.add_task('yes')
+    job_a.add_task('ls')
+    job_a.add_task('cd .')
+    job_a.add_edge('yes', 'ls')
+    job_a.add_edge('ls', 'cd .')
+
+    job_b = dagobah.get_job('test_job_b')
+    job_b.add_task('ls')
+    job_b.add_task('pwd')
+    job_b.add_jobtask('test_job_a')
+    job_b.add_edge('ls', 'test_job_a')
+    job_b.add_edge('test_job_a', 'pwd')
+    graph, tasks = job_b.expand(job_b.graph, job_b.tasks)
+    pprint(graph)
+    assert_equal(pformat(graph),
+                 "{'ls': set(['test_job_a_yes'])," +
+                 "\n 'pwd': set()," +
+                 "\n 'test_job_a_cd .': set(['pwd'])," +
+                 "\n 'test_job_a_ls': set(['test_job_a_cd .'])," +
+                 "\n 'test_job_a_yes': set(['test_job_a_ls'])}")
+
+
+@with_setup(blank_dagobah)
+def test_dagobah_expand_complex_job():
+    dagobah.add_job('JOB_1')
+    dagobah.add_job('JOB_2')
+    dagobah.add_job('JOB_3')
+
+    job_1 = dagobah.get_job('JOB_1')
+    job_1.add_task('yes', 'A')
+    job_1.add_task('ls', 'B')
+    job_1.add_jobtask('JOB_2', 'C')
+    job_1.add_task('time', 'D')
+    job_1.add_task('date', 'E')
+    job_1.add_edge('A', 'C')
+    job_1.add_edge('B', 'C')
+    job_1.add_edge('C', 'D')
+    job_1.add_edge('C', 'E')
+
+    job_2 = dagobah.get_job('JOB_2')
+    job_2.add_task('yes', 'A*')
+    job_2.add_jobtask('JOB_3', 'B*')
+    job_2.add_task('cd .', 'C*')
+    job_2.add_task('time', 'D*')
+    job_2.add_edge('A*', 'B*')
+    job_2.add_edge('A*', 'C*')
+    job_2.add_edge('B*', 'C*')
+    job_2.add_edge('B*', 'D*')
+    job_2.add_edge('C*', 'D*')
+
+    job_3 = dagobah.get_job('JOB_3')
+    job_3.add_task('yes', 'A**')
+    job_3.add_task('ls -lahtr', 'B**')
+    job_3.add_task('cd .', 'C**')
+    job_3.add_task('date', 'D**')
+    job_3.add_edge('A**', 'D**')
+    job_3.add_edge('B**', 'D**')
+    job_3.add_edge('C**', 'D**')
+
+    graph, tasks = job_1.expand(job_1.graph, job_1.tasks)
+    assert_equal(pformat(graph),
+                 "{'A': set(['C_A*'])," +
+                 "\n 'B': set(['C_A*'])," +
+                 "\n 'C_A*': set(['C_C_B*_A**', 'C_C_B*_B**', 'C_C_B*_C**', 'C_C_C*'])," +
+                 "\n 'C_C_B*_A**': set(['C_C_B*_D**'])," +
+                 "\n 'C_C_B*_B**': set(['C_C_B*_D**'])," +
+                 "\n 'C_C_B*_C**': set(['C_C_B*_D**'])," +
+                 "\n 'C_C_B*_D**': set(['C_C_C*', 'C_C_D*'])," +
+                 "\n 'C_C_C*': set(['C_C_D*'])," +
+                 "\n 'C_C_D*': set(['D', 'E'])," +
+                 "\n 'D': set()," +
+                 "\n 'E': set()}")


### PR DESCRIPTION
~~This isn't a final PR, just the introduction of job expansion for scrutiny and debugging.


Right now, I've manually tested a number of dags and verified that job expansion works as we would like it. However, there are some side effects of the new implementation that are causing issues that are causing other tests to fail. I wanted to get you opinion on what's going on.

Here's my general understanding:

* In order to get job expansion to work, not only do we have to create a snapshot of the DAG graph, but we also have to create a snapshot of the task list, as dagobah uses both of these to run a job, so expansion requires the inheretied jobs to be in both maps
* In order to make a snapshot, I'm doing a `deepcopy(self.tasks)`
* There are apparently some thread locks within the tasks that, upon deepcopy, are causing it to barf (because you can't copy thread locks)

I was wondering what you think would be the best solution for this?

My heads a bit fuzzy from debugging all day, but my suspicion is I'll have manually copy by looping over the `tasks` map, and populating a new snapshot map with new task objects, generated from the deserialized json of the current `tasks` map.

But perhaps there is a simpler solution? I'm not very experienced with python threading.~~


This has now been figured out, cleaned, and is ready to be a full PR more or less. Explanation to come.