### PR TITLE
Job in Job: Expansion renaming

### DIFF
--- a/dagobah/core/dagobah.py
+++ b/dagobah/core/dagobah.py
@@ -19,6 +19,7 @@ class Dagobah(object):
     instance, as well as top-level parameters such as the
     backend used for permanent storage.
     """
+    JIJ_DELIM = '%_|JIJ_DELIMITER|_%'
 
     def __init__(self, backend=BaseBackend(), event_handler=None,
                  ssh_config=None):

--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -38,6 +38,7 @@ class Job(DAG):
         self.job_id = job_id
         self.name = name
         self.state = JobState()
+        self.JIJ_DELIM = self.parent.JIJ_DELIM
 
         # tasks themselves aren't hashable, so we need a secondary lookup
         self.tasks = {}
@@ -526,10 +527,10 @@ class Job(DAG):
                 tasks.pop(task)
                 continue
 
-            # Prepend all expanded task names with "<jobname>_" to mitigate
-            # task name conflicts
+            # Prepend all expanded task names with "<jobname>" and delimiter to
+            # mitigate task name conflicts
             for t in expanded_tasks:
-                new_name = "{0}_{1}".format(task, t)
+                new_name = "{0}{1}{2}".format(task, self.JIJ_DELIM, t)
                 expanded_tasks[new_name] = expanded_tasks.pop(t)
                 expanded_tasks[new_name].name = new_name
 

--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -624,7 +624,7 @@ class Job(DAG):
                 continue
 
             logger.debug("Found expandable task: {0} with target job {1}"
-                         .format(task.name, task.target_job_name))
+                         .format(task.pname(), task.target_job_name))
             cur_job = self.parent._resolve_job(task.target_job_name)
             if not cur_job:
                 raise DagobahError("Job with name {0} doesn't exist."

--- a/dagobah/core/jobtask.py
+++ b/dagobah/core/jobtask.py
@@ -20,7 +20,7 @@ class JobTask(object):
         self.delegator = parent_job.delegator
         self.delegator.commit_job(self.parent_job)
 
-    def expand(self, expanding_job=None):
+    def expand(self):
         """ Expand this JobTask into a list of cloned tasks """
         logger.debug("expanding {0}".format(self.target_job_name))
         target_job = self.parent_job.parent._resolve_job(self.target_job_name)

--- a/dagobah/core/jobtask.py
+++ b/dagobah/core/jobtask.py
@@ -43,3 +43,7 @@ class JobTask(object):
     def clone(self):
         cloned_task = JobTask(self.parent_job, self.target_job_name, self.name)
         return cloned_task
+
+    def pname(self, delimiter='|'):
+        """ Pretty name swaps delimiters in the name for readability """
+        return self.name.replace(self.parent_job.parent.JIJ_DELIM, delimiter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ premailer==1.13
 flask-login==0.2.6
 semantic_version==2.3.0
 paramiko==1.11.0
-py-dag==2.2.0
+py-dag==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='dagobah',
                         'flask-login==0.2.6',
                         'semantic_version==2.3.0',
                         'paramiko==1.11.0',
-                        'py-dag==2.2.0'],
+                        'py-dag==2.3.0'],
       test_suite='nose.collector',
       tests_require=['nose', 'pymongo'],
       entry_points={'console_scripts':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,6 @@ from pprint import pprint
 import os
 
 dagobah = None
-JIJ_DELIM = None
 
 
 class DagobahTestTimeoutException(Exception):


### PR DESCRIPTION
This pull requests implements discussion we had regarding the renaming of expanded tasks for Job-in-job functionality.

# Why?

Expanded tasks need to be renamed for a couple reasons:

1. To prevent naming conflicts: task names in dagobah are their "unique" ID. By prepending their name with their parent `jobtask` they were expanded from, name conflicts are eliminated in all but extreme cases.
2. To provide a means of knowing the hierarchy of parents: This is especially important for the front end, which may need to visually represent the expansion. By maintaining each level of parent job, this info can be reconstructed, in order, by simply splitting on the delimiter

# Noted Points of discussion

* Choice of delimiter
    * I chose the current delimiter because it is descriptive and highly unlikely to be collided with unintentionally.
    * I figure there might be some opposition to the slowness of a large delimiter, but I can't imagine a case in which the speed for splitting this would be non-trivial (ie 1000's of job-in-jobs deep)
* Location of delimiter:
    * I chose the Dagobah object because pretty much every object can touch Dagobah.
    * The next alternative is to have it in the config. Is it necessary to make it configurable? (I'm divided on this, would love opinions)

Other than that, commit messages should tell you everything! Bring on the review  :moyai: