### PR TITLE
Add email support for Job-in-Job

### DIFF
--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -312,13 +312,13 @@ class Job(DAG):
             self.backend.release_lock()
 
         if kwargs.get('success', None) is False:
-            task = self.tasks[task_name]
+            task = self.tasks_snapshot[task_name]
             try:
                 self.backend.acquire_lock()
                 if self.event_handler:
-                    self.event_handler.emit('task_failed',
-                                            task._serialize(
-                                                include_run_logs=True))
+                    task_data = task._serialize(include_run_logs=True)
+                    task_data['delimiter'] = self.JIJ_DELIM
+                    self.event_handler.emit('task_failed', task_data)
             except:
                 logger.exception("Error in handling events.")
             finally:

--- a/dagobah/core/job.py
+++ b/dagobah/core/job.py
@@ -354,9 +354,10 @@ class Job(DAG):
                 try:
                     self.backend.acquire_lock()
                     if self.event_handler:
-                        self.event_handler.emit('job_failed',
-                                                self._serialize(
-                                                    include_run_logs=True))
+                        job_data = self._serialize(include_run_logs=True,
+                                                   use_snapshot=True)
+                        job_data['delimiter'] = self.JIJ_DELIM
+                        self.event_handler.emit('job_failed', job_data)
                 except:
                     logger.exception("Error in handling events.")
                 finally:
@@ -370,9 +371,10 @@ class Job(DAG):
             try:
                 self.backend.acquire_lock()
                 if self.event_handler:
-                    self.event_handler.emit('job_complete',
-                                            self._serialize(
-                                                include_run_logs=True))
+                    job_data = self._serialize(include_run_logs=True,
+                                               use_snapshot=True)
+                    job_data['delimiter'] = self.JIJ_DELIM
+                    self.event_handler.emit('job_complete', job_data)
             except:
                 logger.exception("Error in handling events.")
             finally:

--- a/dagobah/email/basic.py
+++ b/dagobah/email/basic.py
@@ -47,7 +47,7 @@ class BasicEmail(EmailTemplate):
         css = self._get_template('basic', 'task_failed.css').render()
 
         self.message = self._merge_templates(template, css)
-        self._construct_and_send('Task Failed: %s' % data.get('name', None))
+        self._construct_and_send('Task Failed: %s' % self._format_name(data))
 
 
     def _format_job_dict(self, job):
@@ -74,3 +74,12 @@ class BasicEmail(EmailTemplate):
         if (not in_date) or (not isinstance(in_date, datetime)):
             return in_date
         return in_date.strftime('%Y-%m-%d %H:%M:%S UTC')
+
+
+    def _format_name(self, data):
+        name = data.get('name', None)
+        delimiter = data.get('delimiter', None)
+        if delimiter and name:
+            name = name.replace(delimiter, '" -> "')
+            name = '"' + name + '"'
+        return name

--- a/dagobah/email/basic.py
+++ b/dagobah/email/basic.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 """ Basic HTML email template for sending out Dagobah communications. """
 
 from datetime import datetime
@@ -80,6 +82,6 @@ class BasicEmail(EmailTemplate):
         name = data.get('name', None)
         delimiter = data.get('delimiter', None)
         if delimiter and name:
-            name = name.replace(delimiter, '" -> "')
+            name = name.replace(delimiter, u'" ⟶ "')
             name = '"' + name + '"'
         return name

--- a/dagobah/email/templates/basic/job_completed.html
+++ b/dagobah/email/templates/basic/job_completed.html
@@ -1,4 +1,5 @@
 <body>
+  {% set new_delim = "<br \>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#8627;" -%}
 
   <h1 class='email-heading'>Job Successful: {{ job.name }}</h1>
 
@@ -27,7 +28,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td>{{ task.command }}</td>
           <td>{{ task.success }}</td>
           <td>{{ task.run_log.return_code }}</td>
@@ -47,7 +48,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td>{{ task.started_at }}</td>
           <td>{{ task.completed_at }}</td>
         </tr>
@@ -65,7 +66,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td><pre>{{ task.run_log.stdout }}</pre></td>
         </tr>
       {% endfor %}
@@ -82,7 +83,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td><pre>{{ task.run_log.stderr }}</pre></td>
         </tr>
       {% endfor %}

--- a/dagobah/email/templates/basic/job_failed.html
+++ b/dagobah/email/templates/basic/job_failed.html
@@ -1,4 +1,5 @@
 <body>
+  {% set new_delim = "<br \>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#8627;" -%}
 
   <h1 class='email-heading'>Job Failed: {{ job.name }}</h1>
 
@@ -27,7 +28,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td>{{ task.command }}</td>
           <td>{{ task.success }}</td>
           <td>{{ task.run_log.return_code }}</td>
@@ -47,7 +48,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td>{{ task.started_at }}</td>
           <td>{{ task.completed_at }}</td>
         </tr>
@@ -65,7 +66,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td><pre>{{ task.run_log.stdout }}</pre></td>
         </tr>
       {% endfor %}
@@ -82,7 +83,7 @@
     <tbody>
       {% for task in job.tasks %}
         <tr>
-          <td>{{ task.name }}</td>
+          <td>{{ task.name|replace(job.delimiter,new_delim) }}</td>
           <td><pre>{{ task.run_log.stderr }}</pre></td>
         </tr>
       {% endfor %}

--- a/dagobah/email/templates/basic/task_failed.html
+++ b/dagobah/email/templates/basic/task_failed.html
@@ -1,7 +1,7 @@
 <body>
   {% set new_delim = "<br \>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#8627;" -%}
 
-  <h1 class='email-heading'>Task Failed: {{ task.name|replace(task.delimiter," -> ") }}</h1>
+  <h1 class='email-heading'>Task Failed: {{ task.name|replace(task.delimiter," &#10230 ") }}</h1>
 
   <h2 class='section-heading'>Run Results</h2>
 

--- a/dagobah/email/templates/basic/task_failed.html
+++ b/dagobah/email/templates/basic/task_failed.html
@@ -1,6 +1,7 @@
 <body>
+  {% set new_delim = "<br \>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#8627;" -%}
 
-  <h1 class='email-heading'>Task Failed: {{ task.name }}</h1>
+  <h1 class='email-heading'>Task Failed: {{ task.name|replace(task.delimiter," -> ") }}</h1>
 
   <h2 class='section-heading'>Run Results</h2>
 
@@ -13,7 +14,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{ task.name }}</td>
+        <td>{{ task.name|replace(task.delimiter,new_delim) }}</td>
         <td>{{ task.command }}</td>
         <td>{{ task.success }}</td>
         <td>{{ task.run_log.return_code }}</td>
@@ -31,7 +32,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{ task.name }}</td>
+        <td>{{ task.name|replace(task.delimiter,new_delim) }}</td>
         <td>{{ task.started_at }}</td>
         <td>{{ task.completed_at }}</td>
       </tr>
@@ -47,7 +48,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{ task.name }}</td>
+        <td>{{ task.name|replace(task.delimiter,new_delim) }}</td>
         <td><pre>{{ task.run_log.stdout }}</pre></td>
       </tr>
     </tbody>
@@ -62,7 +63,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{ task.name }}</td>
+        <td>{{ task.name|replace(task.delimiter,new_delim) }}</td>
         <td><pre>{{ task.run_log.stderr }}</pre></td>
       </tr>
     </tbody>


### PR DESCRIPTION
This PR is designed to provide email support for job in job tasks. It includes a few things:

* Adjustments to event emissions in `job.py` to pass the `delimiter` in the JSON blob on to event handlers (such as email)
* Email template changes (both text and basic) to make task names more readable in emails
* Minor fix to task failure to reference the task snapshot instead of the original list

Here's some snippets of the new emails: 

Text email, success (truncated):

```
Subject: Job Completed: Test C

Job name: Test C
Cron schedule: None
Next run: None

Parent ID: 565e24c3ee752593dfb7b682
Job ID: 568eb420ee752561d499de0e

Tasks Detail

Task: "Test A 1" -> "ls"
Command: ls
Result: Success
Started at: 2016-01-20 20:15:59 UTC
Completed at: 2016-01-20 20:16:02 UTC
Return Code: 0
Stdout: CHANGELOG.md
LICENSE
MAINTAINERS
MANIFEST.in
README.md
dagobah
dagobah.egg-info
memory
requirements.txt
setup.py
tests

Stderr:
```

Text, task failure:
```
Subject: Task Failed: "failtask" -> "no"

Task: "failtask" -> "no"
Command: no
Result: Failed
Started at: 2016-01-20 20:22:28 UTC
Completed at: 2016-01-20 20:22:30 UTC
Return Code: 127
Stdout:
Stderr: /bin/sh: no: command not found
```

Basic, Success:
![screenshot 2016-01-20 15 25 40](https://cloud.githubusercontent.com/assets/186589/12462053/3f14fe04-bf8a-11e5-80ae-7da37d4da1b4.png)

Basic, Task failure:

![screenshot 2016-01-20 15 25 00](https://cloud.githubusercontent.com/assets/186589/12462072/58321516-bf8a-11e5-8d7d-b427b88ade2d.png)

Didn't include any job failure emails cause they look just like a combination of the task failure and job completion emails in terms of formatting.